### PR TITLE
Enhancements to Arista EOS show ip mroute

### DIFF
--- a/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
+++ b/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
@@ -13,27 +13,27 @@ Start
   ^VRF:${VRF}
   ^PIM
   ^RPF
-  ^\s+M\s-
+  ^\s+M\s+-\s+From
   ^Flags
-  ^\s{4}[RWIHZANTVF]\s-
+  ^\s{4}[RWIHZANTVF]\s+-
   ^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) -> Continue.Record
   ^${MULTICAST_GROUP}
   ^\s{2}(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) -> Continue.Record
   ^\s{2}${RPF_SOURCE},\s+${UPTIME},\s+(RP\s${RP},\s+)?flags:\s+${FLAGS}
-  ^\s{4}Incoming\sinterface:\s${INCOMING_INTERFACE}
-  ^\s{4}Outgoing\sinterface\slist:
+  ^\s{4}Incoming\s+interface:\s+${INCOMING_INTERFACE}
+  ^\s{4}Outgoing\s+interface\s+list:
   ^\s{6}${OUTGOING_INTERFACE_LIST}$$
   ^\s{4}\S\s-> Continue
-  ^\s{4}Interfaces\snot\sin\sOIL
+  ^\s{4}Interfaces\s+not\s+in\s+OIL
   ^\s{6}\S+
-  ^\s{4}Upstream\sjoined\sstate:\s${UPSTREAM_JOINED_STATE}
-  ^\s{4}Upstream\sRPT\sjoined\sstate:\s${UPSTREAM_RPT_JOINED_STATE} -> Record
-  ^\s{4}State\ssummarization\smacros:
-  ^\s{6}Could
-  ^\s{6}Register
-  ^\s{6}Join
-  ^\s{6}RPT\sjoin\sdesired
-  ^\s{6}Prune
+  ^\s{4}Upstream\s+joined\s+state:\s+${UPSTREAM_JOINED_STATE}
+  ^\s{4}Upstream\s+RPT\s+joined\s+state:\s+${UPSTREAM_RPT_JOINED_STATE} -> Record
+  ^\s+State\s+summarization\s+macros:
+  ^\s+Could
+  ^\s+Register
+  ^\s+Join
+  ^\s{6}RPT\s+join\s+desired
+  ^\s+Prune
   ^\s{6}No\s+interfaces\s+in\s+(immediate|inherited)\s+olist
   ^.* -> Error
 

--- a/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
+++ b/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
@@ -25,8 +25,8 @@ Start
   ^\s{4}\S\s -> Continue
   ^\s+Interfaces\s+not\s+in\s+OIL
   ^\s{6}\S+
-  ^\s{4}Upstream\s+joined\s+state:\s+${UPSTREAM_JOINED_STATE}
-  ^\s{4}Upstream\s+RPT\s+joined\s+state:\s+${UPSTREAM_RPT_JOINED_STATE} -> Record
+  ^\s+Upstream\s+joined\s+state:\s+${UPSTREAM_JOINED_STATE}
+  ^\s+Upstream\s+RPT\s+joined\s+state:\s+${UPSTREAM_RPT_JOINED_STATE} -> Record
   ^\s+State\s+summarization\s+macros:
   ^\s+Could
   ^\s+Register

--- a/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
+++ b/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
@@ -22,7 +22,7 @@ Start
   ^\s{4}Incoming\s+interface:\s+${INCOMING_INTERFACE}
   ^\s{4}Outgoing\s+interface\s+list:
   ^\s{6}${OUTGOING_INTERFACE_LIST}$$
-  ^\s{4}\S\s-> Continue
+  ^\s{4}\S\s -> Continue
   ^\s{4}Interfaces\s+not\s+in\s+OIL
   ^\s{6}\S+
   ^\s{4}Upstream\s+joined\s+state:\s+${UPSTREAM_JOINED_STATE}

--- a/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
+++ b/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
@@ -18,12 +18,12 @@ Start
   ^\s{4}[RWIHZANTVF]\s+-
   ^${MULTICAST_GROUP}
   ^\s+?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) -> Continue.Record
-  ^\s{2}${RPF_SOURCE},\s+${UPTIME},\s+(RP\s${RP},\s+)?flags:\s+${FLAGS}
-  ^\s{4}Incoming\s+interface:\s+${INCOMING_INTERFACE}
-  ^\s{4}Outgoing\s+interface\s+list:
+  ^\s{2}${RPF_SOURCE},\s+${UPTIME},\s+(RP\s+${RP},\s+)?flags:\s+${FLAGS}
+  ^\s+Incoming\s+interface:\s+${INCOMING_INTERFACE}
+  ^\s+Outgoing\s+interface\s+list:
   ^\s{6}${OUTGOING_INTERFACE_LIST}$$
   ^\s{4}\S\s -> Continue
-  ^\s{4}Interfaces\s+not\s+in\s+OIL
+  ^\s+Interfaces\s+not\s+in\s+OIL
   ^\s{6}\S+
   ^\s{4}Upstream\s+joined\s+state:\s+${UPSTREAM_JOINED_STATE}
   ^\s{4}Upstream\s+RPT\s+joined\s+state:\s+${UPSTREAM_RPT_JOINED_STATE} -> Record
@@ -31,9 +31,9 @@ Start
   ^\s+Could
   ^\s+Register
   ^\s+Join
-  ^\s{6}RPT\s+join\s+desired
+  ^\s+RPT\s+join\s+desired
   ^\s+Prune
-  ^\s{6}No\s+interfaces\s+in\s+(immediate|inherited)\s+olist
+  ^\s+No\s+interfaces\s+in\s+(immediate|inherited)\s+olist
   ^.* -> Error
 
 EOF

--- a/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
+++ b/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
@@ -16,9 +16,8 @@ Start
   ^\s+M\s+-\s+From
   ^Flags
   ^\s{4}[RWIHZANTVF]\s+-
-  ^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) -> Continue.Record
   ^${MULTICAST_GROUP}
-  ^\s{2}(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) -> Continue.Record
+  ^\s+?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) -> Continue.Record
   ^\s{2}${RPF_SOURCE},\s+${UPTIME},\s+(RP\s${RP},\s+)?flags:\s+${FLAGS}
   ^\s{4}Incoming\s+interface:\s+${INCOMING_INTERFACE}
   ^\s{4}Outgoing\s+interface\s+list:

--- a/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
+++ b/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
@@ -15,13 +15,13 @@ Start
   ^RPF
   ^\s+M\s+-\s+From
   ^Flags
-  ^\s{4}[RWIHZANTVF]\s+-
+  ^\s+[RWIHZANTVF]\s+-
   ^${MULTICAST_GROUP}
   ^\s+?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) -> Continue.Record
-  ^\s{2}${RPF_SOURCE},\s+${UPTIME},\s+(RP\s+${RP},\s+)?flags:\s+${FLAGS}
+  ^\s+${RPF_SOURCE},\s+${UPTIME},\s+(RP\s+${RP},\s+)?flags:\s+${FLAGS}
   ^\s+Incoming\s+interface:\s+${INCOMING_INTERFACE}
   ^\s+Outgoing\s+interface\s+list:
-  ^\s{6}${OUTGOING_INTERFACE_LIST}$$
+  ^\s+${OUTGOING_INTERFACE_LIST}$$
   ^\s{4}\S\s -> Continue
   ^\s+Interfaces\s+not\s+in\s+OIL
   ^\s{6}\S+

--- a/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
+++ b/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
@@ -22,9 +22,9 @@ Start
   ^\s+Incoming\s+interface:\s+${INCOMING_INTERFACE}
   ^\s+Outgoing\s+interface\s+list:
   ^\s+${OUTGOING_INTERFACE_LIST}$$
-  ^\s{4}\S\s -> Continue
   ^\s+Interfaces\s+not\s+in\s+OIL
-  ^\s{6}\S+
+# match interface names that are not in the OIL
+  ^\s+\S+:\s+
   ^\s+Upstream\s+joined\s+state:\s+${UPSTREAM_JOINED_STATE}
   ^\s+Upstream\s+RPT\s+joined\s+state:\s+${UPSTREAM_RPT_JOINED_STATE} -> Record
   ^\s+State\s+summarization\s+macros:

--- a/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
+++ b/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
@@ -19,8 +19,7 @@ Start
   ^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) -> Continue.Record
   ^${MULTICAST_GROUP}
   ^\s{2}(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) -> Continue.Record
-  ^\s{2}${RPF_SOURCE},\s${UPTIME},\sflags:\s${FLAGS}
-  ^\s{2}${RPF_SOURCE},\s${UPTIME},\sRP\s${RP},\sflags:\s${FLAGS}
+  ^\s{2}${RPF_SOURCE},\s+${UPTIME},\s+(RP\s${RP},\s+)?flags:\s+${FLAGS}
   ^\s{4}Incoming\sinterface:\s${INCOMING_INTERFACE}
   ^\s{4}Outgoing\sinterface\slist:
   ^\s{6}${OUTGOING_INTERFACE_LIST}$$
@@ -35,8 +34,7 @@ Start
   ^\s{6}Join
   ^\s{6}RPT\sjoin\sdesired
   ^\s{6}Prune
-  ^\s{6}No\sinterfaces\sin\simmediate\solist
-  ^\s{6}No\sinterfaces\sin\sinherited\solist
+  ^\s{6}No\s+interfaces\s+in\s+(immediate|inherited)\s+olist
   ^.* -> Error
 
 EOF


### PR DESCRIPTION
Second attempt at some tweaks ... well suggestions, but only if they work.

* Pattern consolidation for a few lines
* Flexible whitespace regex between words
* Adjust leading whitespace to be a bit more flexible
   * Believe it or not I managed to get it to parse and the YAML still matches (as it must!)
* Anchor one loose "not in OIL" interface list line a bit more
* Reduce apparently unnecessary Continue action line (works without it)